### PR TITLE
Refactor duplicate permission hook

### DIFF
--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -6,7 +6,6 @@ import { Spinner } from '@/components/ui/spinner';
 import { useAuthSession } from '@/hooks/use-auth-session';
 import { toast } from 'sonner';
 import { ClientPermissionService } from '@/lib/permissions/client-permission-service';
-import { useHasPermission } from '@/hooks/use-permission';
 
 interface AuthGuardProps {
   children: React.ReactNode;

--- a/components/dashboard/role-dashboard.tsx
+++ b/components/dashboard/role-dashboard.tsx
@@ -2,7 +2,8 @@
 
 import { useSession } from 'next-auth/react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { useUserRole, useUserPermissions, useHasPermission } from '@/hooks/use-permission';
+import { useUserRole, useUserPermissions } from '@/hooks/use-permission';
+import { useHasPermission } from '@/hooks/use-has-permission';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CheckCircle2, ShieldAlert, ShieldCheck } from 'lucide-react';

--- a/hooks/use-permission.ts
+++ b/hooks/use-permission.ts
@@ -141,69 +141,6 @@ export function useUserPermissions() {
   return { permissions, isLoading };
 }
 
-/**
- * Hook to check if the current user has a specific permission
- * Uses both client-side and server-side permission checks for optimal performance
- * This is the preferred hook for checking permissions
- *
- * @param permission The permission to check
- * @param redirectTo Optional URL to redirect to if the user doesn't have the permission
- * @returns An object with hasPermission, isLoading, and error properties
- */
-export function useHasPermission(permission: string, redirectTo?: string) {
-  const { session } = useAuthSession();
-  const [hasPermission, setHasPermission] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    // If no session, user doesn't have permission
-    if (!session?.user?.id) {
-      setHasPermission(false);
-      setIsLoading(false);
-      return;
-    }
-
-    // Use the client permission service for a quick initial check
-    const userId = session.user.id;
-    const quickResult = ClientPermissionService.hasPermissionByIdSync(userId, permission);
-
-    // If the quick check passes, we can return true immediately
-    if (quickResult) {
-      setHasPermission(true);
-      setIsLoading(false);
-      return;
-    }
-
-    // If quick check fails, verify with the API
-    // This handles the case where permissions might be in the database but not in the client cache
-    setIsLoading(true);
-
-    fetch(
-      `/api/users/check-permission?userId=${encodeURIComponent(userId)}&permission=${encodeURIComponent(permission)}`
-    )
-      .then(res => res.json())
-      .then(data => {
-        setHasPermission(data.hasPermission);
-        setIsLoading(false);
-
-        // Handle redirection if needed
-        if (redirectTo && !data.hasPermission) {
-          window.location.href = redirectTo;
-        }
-      })
-      .catch(err => {
-        console.error('Error checking permission:', err);
-        setError('Failed to check permission');
-        // Fall back to the client-side check on error
-        setHasPermission(quickResult);
-        setIsLoading(false);
-      });
-  }, [session, permission, redirectTo]);
-
-  return { hasPermission, isLoading, error };
-}
-
 export function useUserRole() {
   const { session, status } = useAuthSession();
   const [role, setRole] = useState<string>('');


### PR DESCRIPTION
## Summary
- clean up `use-permission` by removing the duplicate `useHasPermission` implementation
- update components to import `useHasPermission` from its dedicated module
- drop unused import in `AuthGuard`

## Testing
- `npm run build:direct` *(fails: request to https://binaries.prisma.sh/...)*
- `npm run type-check` *(fails: type errors in existing code)*
- `npm run lint` *(fails: 19 errors, 1056 warnings)*