### PR TITLE
Fix task imports and simplify ActivityWhereInput export

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -12,7 +12,7 @@ export * from './task';
 export * from './attendance';
 export * from './permission';
 export * from './document';
-export * from './activity';
+export type { Activity, ActivityWithRelations, CreateActivityDTO } from './activity';
 export * from './dashboard';
 
 // Re-export types from infrastructure files

--- a/types/task.ts
+++ b/types/task.ts
@@ -9,6 +9,7 @@
 import { ActivityWithRelations } from './activity';
 import { UserSummary } from './user';
 import { Document, DocumentWithRelations } from './document';
+import type { ProjectStatus } from './project';
 
 // Re-export ProjectStatus for components that need it
 export type { ProjectStatus } from './project';
@@ -35,7 +36,7 @@ export interface Task {
   completed: boolean;
   // Optional properties that might be included in some contexts
   assignees?: TaskAssignee[];
-  status?: import('./project').ProjectStatus | null;
+  status?: ProjectStatus | null;
   project: {
     id: string;
     title: string;


### PR DESCRIPTION
## Summary
- add ProjectStatus import for task types
- avoid duplicate ActivityWhereInput export

## Testing
- `npm run type-check` *(fails: Cannot find module 'next-auth/providers', and various type errors)*