### PR TITLE
Remove console logs in production

### DIFF
--- a/components/attendance/attendance-history.tsx
+++ b/components/attendance/attendance-history.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState, useEffect } from 'react';
 import {
@@ -152,7 +153,7 @@ export function AttendanceHistory() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     // Implement search functionality
-    console.log('Searching for:', searchQuery);
+    devLog('Searching for:', searchQuery);
     // Reset to page 1 when searching
     setPage(1);
     fetchAttendanceHistory();

--- a/components/attendance/attendance-widget.tsx
+++ b/components/attendance/attendance-widget.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import {
@@ -101,7 +102,7 @@ export function AttendanceWidget() {
         if (registered && syncSupported) {
           // Register for background sync
           await registerBackgroundSync();
-          console.log('Background sync registered successfully');
+          devLog('Background sync registered successfully');
         }
 
         // Load pending actions from IndexedDB
@@ -118,17 +119,17 @@ export function AttendanceWidget() {
   // Listen for service worker messages with enhanced handling
   useEffect(() => {
     const cleanup = listenForServiceWorkerMessages(data => {
-      console.log('Service worker message received:', data.type);
+      devLog('Service worker message received:', data.type);
 
       switch (data.type) {
         case 'SYNC_SUCCESS':
-          console.log('Sync success:', data.record);
+          devLog('Sync success:', data.record);
           // Refresh attendance data after successful sync
           fetchAttendance();
           break;
 
         case 'SYNC_REDUNDANT':
-          console.log('Sync redundant:', data.record, data.message);
+          devLog('Sync redundant:', data.record, data.message);
           // This is a "success" case where the server state already matches what we wanted
           toast({
             title: 'Already Synchronized',
@@ -140,7 +141,7 @@ export function AttendanceWidget() {
           break;
 
         case 'SYNC_FAILURE':
-          console.log('Sync failure:', data.record, data.error);
+          devLog('Sync failure:', data.record, data.error);
           toast({
             title: 'Sync Failed',
             description: data.error || 'Failed to sync attendance record.',
@@ -151,7 +152,7 @@ export function AttendanceWidget() {
           break;
 
         case 'SYNC_PERMANENT_FAILURE':
-          console.log('Sync permanent failure:', data.record, data.error);
+          devLog('Sync permanent failure:', data.record, data.error);
           toast({
             title: 'Sync Failed Permanently',
             description: `An attendance record could not be synced after multiple attempts: ${data.error}`,
@@ -162,7 +163,7 @@ export function AttendanceWidget() {
           break;
 
         case 'SYNC_COMPLETED': {
-          console.log('Sync completed:', data.results);
+          devLog('Sync completed:', data.results);
           setSyncInProgress(false);
 
           // Refresh pending actions
@@ -221,7 +222,7 @@ export function AttendanceWidget() {
         }
 
         default:
-          console.log('Unknown message type:', data.type, data);
+          devLog('Unknown message type:', data.type, data);
       }
     });
 

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
@@ -35,7 +36,7 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
     setSuccess('');
 
     try {
-      console.log('Attempting to sign in with:', { email, callbackUrl });
+      devLog('Attempting to sign in with:', { email, callbackUrl });
 
       const result = await signIn('credentials', {
         redirect: false,
@@ -44,12 +45,12 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
         callbackUrl: redirectUrl,
       });
 
-      console.log('Sign in result:', result);
+      devLog('Sign in result:', result);
 
       if (result?.error) {
         setError('Invalid email or password');
       } else {
-        console.log('Redirecting to:', redirectUrl);
+        devLog('Redirecting to:', redirectUrl);
         // Use window.location for a hard redirect without delay
         window.location.href = redirectUrl;
       }

--- a/components/profile/unified-profile-view.tsx
+++ b/components/profile/unified-profile-view.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -56,7 +57,7 @@ export function UnifiedProfileView({
     if (files && files.length > 0) {
       try {
         const file = files[0];
-        console.log('File selected:', file.name);
+        devLog('File selected:', file.name);
 
         // Create form data
         const formData = new FormData();

--- a/components/profile/user-attendance-summary.tsx
+++ b/components/profile/user-attendance-summary.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -38,7 +39,7 @@ export function UserAttendanceSummary({ userId }: UserAttendanceSummaryProps) {
         setIsError(false);
         setErrorMessage('');
 
-        console.log(`Fetching attendance for user ${userId}`);
+        devLog(`Fetching attendance for user ${userId}`);
         const response = await fetch(`/api/users/${userId}/attendance?limit=5`);
 
         if (!response.ok) {
@@ -47,7 +48,7 @@ export function UserAttendanceSummary({ userId }: UserAttendanceSummaryProps) {
         }
 
         const data = await response.json();
-        console.log('Attendance data:', data);
+        devLog('Attendance data:', data);
 
         // Set attendance records with safety checks
         if (Array.isArray(data.attendanceRecords)) {

--- a/components/project/kanban-board.tsx
+++ b/components/project/kanban-board.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState, useRef, useEffect } from 'react';
 import {
@@ -139,7 +140,7 @@ export function KanbanBoard({
         );
 
         // Log for debugging
-        console.log(`Dragging over status column: ${overId}`);
+        devLog(`Dragging over status column: ${overId}`);
       }
     }
 
@@ -226,11 +227,11 @@ export function KanbanBoard({
       // If dropping onto a status column
       if (over.data.current?.type === 'status') {
         const newStatusId = over.id.toString();
-        console.log(`Dropping onto status column: ${newStatusId}`);
+        devLog(`Dropping onto status column: ${newStatusId}`);
 
         // If the status is changing
         if (activeTaskData.statusId !== newStatusId) {
-          console.log(`Moving task ${activeTaskData.id} to status ${newStatusId}`);
+          devLog(`Moving task ${activeTaskData.id} to status ${newStatusId}`);
           // No target task ID needed when dropping onto an empty column
           await moveTask(activeTaskData.id, newStatusId);
         }

--- a/components/project/status-column.tsx
+++ b/components/project/status-column.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -56,7 +57,7 @@ export const StatusColumn = React.memo(function StatusColumnImpl({
 
   // Log when a column is being dragged over
   if (isOver) {
-    console.log(`Status column ${status.id} (${status.name}) is being dragged over`);
+    devLog(`Status column ${status.id} (${status.name}) is being dragged over`);
   }
 
   // Calculate classes for different states

--- a/components/project/task-context.tsx
+++ b/components/project/task-context.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { useToast } from '@/hooks/use-toast';
@@ -57,7 +58,7 @@ export function TaskProvider({
       const url =
         projectId === 'all' ? `/api/projects/all/statuses` : `/api/projects/${projectId}/statuses`;
 
-      console.log('Fetching statuses from URL:', url);
+      devLog('Fetching statuses from URL:', url);
       const response = await fetch(url);
       if (!response.ok) throw new Error('Failed to fetch statuses');
       const data = await response.json();
@@ -107,7 +108,7 @@ export function TaskProvider({
           ? `/api/team-management/all?limit=100`
           : `/api/team-management?projectId=${projectId}`;
 
-      console.log('Fetching users from URL:', url);
+      devLog('Fetching users from URL:', url);
       const response = await fetch(url);
       if (!response.ok) throw new Error('Failed to fetch users');
       const data = await response.json();
@@ -539,7 +540,7 @@ export function TaskProvider({
     const handleRefreshTasks = (event: any) => {
       // Check if this event is for our project
       if (event.detail?.projectId === projectId) {
-        console.log('TaskContext received refresh event for project:', projectId);
+        devLog('TaskContext received refresh event for project:', projectId);
         fetchTasks();
       }
     };

--- a/components/project/task-form.tsx
+++ b/components/project/task-form.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import * as React from 'react';
 import { useState, useEffect } from 'react';
@@ -161,7 +162,7 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
             .map((tm: { user: User }) => tm.user)
             .filter((user: User | null) => user && user.id);
 
-          console.log(`Fetched ${users.length} team members for task assignment`);
+          devLog(`Fetched ${users.length} team members for task assignment`);
           setTeamMembers(users);
         } else {
           console.error('No team members data found:', data);
@@ -225,11 +226,11 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
         const data = await response.json();
         const task = data.task;
 
-        console.log('Fetched task data:', task);
+        devLog('Fetched task data:', task);
 
         // Extract assignee IDs from the task
         const assigneeIds = task.assignees?.map((a: { userId: string }) => a.userId) || [];
-        console.log('Extracted assignee IDs:', assigneeIds);
+        devLog('Extracted assignee IDs:', assigneeIds);
 
         if (task) {
           // Format dates as YYYY-MM-DD for HTML date inputs
@@ -273,7 +274,7 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
   const onSubmit = async (values: TaskFormValues): Promise<void> => {
     try {
       setIsLoading(true);
-      console.log('Form submission started with values:', values);
+      devLog('Form submission started with values:', values);
 
       const endpoint = taskId ? `/api/tasks/${taskId}` : '/api/tasks';
 
@@ -300,19 +301,19 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
         dueDate: values.dueDate ? new Date(values.dueDate).toISOString() : null,
       };
 
-      console.log('Submitting task with dates:', {
+      devLog('Submitting task with dates:', {
         startDate: payload.startDate,
         endDate: payload.endDate,
         dueDate: payload.dueDate,
       });
 
       // Log assignee information
-      console.log('Assignee IDs being submitted:', values.assigneeIds);
-      console.log(
+      devLog('Assignee IDs being submitted:', values.assigneeIds);
+      devLog(
         'Team members available:',
         teamMembers.map(m => ({ id: m.id, name: m.name || m.email }))
       );
-      console.log('Submitting task data:', payload);
+      devLog('Submitting task data:', payload);
 
       const response = await fetch(endpoint, {
         method,
@@ -322,7 +323,7 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
         body: JSON.stringify(payload),
       });
 
-      console.log('Response status:', response.status);
+      devLog('Response status:', response.status);
 
       if (!response.ok) {
         const errorData = await response
@@ -333,7 +334,7 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
       }
 
       const result = await response.json();
-      console.log('Task form submission result:', result);
+      devLog('Task form submission result:', result);
 
       // Try to refresh the task context if we're in a project context
       try {
@@ -343,7 +344,7 @@ export function TaskForm({ projectId, taskId, parentId, onSuccess, onCancel }: T
         });
         if (typeof window !== 'undefined') {
           window.dispatchEvent(taskContextRefreshEvent);
-          console.log('Dispatched refreshTasks event');
+          devLog('Dispatched refreshTasks event');
         }
       } catch (refreshError) {
         console.warn('Could not refresh task context:', refreshError);

--- a/components/projects/create-status-modal.tsx
+++ b/components/projects/create-status-modal.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState } from 'react';
 import {
@@ -84,7 +85,7 @@ export function CreateStatusModal({
         throw new Error(data.error || 'Failed to create status');
       }
 
-      console.log('Status creation response:', data);
+      devLog('Status creation response:', data);
 
       toast({
         title: 'Status created',
@@ -123,7 +124,7 @@ export function CreateStatusModal({
     } catch (err: any) {
       console.error('Error creating status:', err);
       const errorMessage = err.message || 'Failed to create status. Please try again.';
-      console.log('Setting error message:', errorMessage);
+      devLog('Setting error message:', errorMessage);
       setError(errorMessage);
     } finally {
       setIsSubmitting(false);

--- a/components/service-worker-provider.tsx
+++ b/components/service-worker-provider.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useEffect, useState } from 'react';
 import { registerServiceWorker, isServiceWorkerSupported } from '@/lib/service-worker';
@@ -16,18 +17,18 @@ export function ServiceWorkerProvider({ children }: { children: React.ReactNode 
 
     // Check if service workers are supported
     if (!isServiceWorkerSupported()) {
-      console.log('Service Workers are not supported in this browser');
+      devLog('Service Workers are not supported in this browser');
       return;
     }
 
     const registerSW = async () => {
       try {
-        console.log('Attempting to register Service Worker...');
+        devLog('Attempting to register Service Worker...');
         const registered = await registerServiceWorker();
         setSwRegistered(registered);
 
         if (registered) {
-          console.log('✅ Service Worker registered successfully');
+          devLog('✅ Service Worker registered successfully');
         } else {
           console.warn('⚠️ Service Worker registration failed - check console for details');
         }
@@ -56,7 +57,7 @@ export function ServiceWorkerProvider({ children }: { children: React.ReactNode 
         const registrations = await navigator.serviceWorker.getRegistrations();
 
         if (registrations.length === 0 && !swRegistered) {
-          console.log('No service worker found, attempting to register');
+          devLog('No service worker found, attempting to register');
           const registered = await registerServiceWorker();
           setSwRegistered(registered);
         }
@@ -69,7 +70,7 @@ export function ServiceWorkerProvider({ children }: { children: React.ReactNode 
 
     // Also check when the app comes back online
     const handleOnline = () => {
-      console.log('App is back online, checking service worker registration');
+      devLog('App is back online, checking service worker registration');
       checkRegistration();
     };
 

--- a/components/team-table.tsx
+++ b/components/team-table.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -90,7 +91,7 @@ export function TeamTable({ projectId }: TeamTableProps) {
   // Function to handle search (for a complete implementation, this would need backend support)
   const handleSearch = () => {
     // In a real implementation, you'd pass this to the API
-    console.log('Searching for:', searchQuery);
+    devLog('Searching for:', searchQuery);
   };
 
   // Role badge styling is now handled by the RoleBadge component

--- a/components/team/team-nav-item.tsx
+++ b/components/team/team-nav-item.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState } from 'react';
 import Link from 'next/link';
@@ -90,7 +91,7 @@ export function TeamNavItem({ collapsed = false }: TeamNavItemProps) {
 
     // Only log in development mode
     if (process.env.NODE_ENV === 'development') {
-      console.log(`Permission check for ${item.title}: ${item.permission} = ${hasPermission}`);
+      devLog(`Permission check for ${item.title}: ${item.permission} = ${hasPermission}`);
     }
 
     // Always show these items for admin users regardless of permission check

--- a/components/team/user-list.tsx
+++ b/components/team/user-list.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { devLog } from '@/lib/utils/logger';
 
 import { useState, ReactNode } from 'react';
 import Link from 'next/link';
@@ -119,7 +120,7 @@ export function UserList({
     setIsDeleting(true);
 
     try {
-      console.log(`Attempting to delete user: ${userToDelete.id}`);
+      devLog(`Attempting to delete user: ${userToDelete.id}`);
 
       const response = await fetch(`/api/users/${userToDelete.id}`, {
         method: 'DELETE',
@@ -132,13 +133,13 @@ export function UserList({
       let responseBody;
       try {
         responseBody = await response.json();
-        console.log('Response body:', responseBody);
+        devLog('Response body:', responseBody);
       } catch (e) {
         console.error('Could not parse response as JSON:', e);
       }
 
       if (!response.ok) {
-        console.log(`Error response: ${response.status} - ${response.statusText}`);
+        devLog(`Error response: ${response.status} - ${response.statusText}`);
 
         // Special handling for users with associated data
         if (response.status === 409) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,3 +1,4 @@
+import { devLog } from '@/lib/utils/logger';
 /**
  * API client utility for making requests to our backend API
  */
@@ -167,13 +168,13 @@ export const userApi = {
   },
 
   updateUserProfile: async (userId: string, profileData: any) => {
-    console.log('Updating user profile:', userId, profileData);
+    devLog('Updating user profile:', userId, profileData);
     try {
       const result = await fetchAPI(`/api/users/${userId}`, {
         method: 'PATCH',
         body: JSON.stringify(profileData),
       });
-      console.log('Update profile result:', result);
+      devLog('Update profile result:', result);
       return result;
     } catch (error) {
       console.error('Error in updateUserProfile:', error);
@@ -182,14 +183,7 @@ export const userApi = {
   },
 
   uploadProfileImage: async (userId: string, file: File) => {
-    console.log(
-      'Uploading profile image for user:',
-      userId,
-      'File:',
-      file.name,
-      file.type,
-      file.size
-    );
+    devLog('Uploading profile image for user:', userId, 'File:', file.name, file.type, file.size);
     const formData = new FormData();
     formData.append('image', file);
 
@@ -207,7 +201,7 @@ export const userApi = {
       }
 
       const result = await response.json();
-      console.log('Profile image upload result:', result);
+      devLog('Profile image upload result:', result);
       return result;
     } catch (error) {
       console.error('Error in uploadProfileImage:', error);
@@ -291,10 +285,10 @@ export const projectApi = {
       });
     }
 
-    console.log('Fetching projects with URL:', `/api/projects?${params.toString()}`);
+    devLog('Fetching projects with URL:', `/api/projects?${params.toString()}`);
     try {
       const result = await fetchAPI(`/api/projects?${params.toString()}`);
-      console.log('Projects API response:', result);
+      devLog('Projects API response:', result);
       return result;
     } catch (error) {
       console.error('Error fetching projects:', error);
@@ -303,10 +297,10 @@ export const projectApi = {
   },
 
   getProject: async (id: string) => {
-    console.log('API client: Getting project with ID:', id);
+    devLog('API client: Getting project with ID:', id);
     try {
       const result = await fetchAPI(`/api/projects/${id}`);
-      console.log('API client: Get project response:', result);
+      devLog('API client: Get project response:', result);
       return result;
     } catch (error) {
       console.error('API client: Error getting project:', error);
@@ -322,13 +316,13 @@ export const projectApi = {
   },
 
   updateProject: async (id: string, project: any) => {
-    console.log('API client: Updating project with ID:', id, 'Data:', project);
+    devLog('API client: Updating project with ID:', id, 'Data:', project);
     try {
       const result = await fetchAPI(`/api/projects/${id}`, {
         method: 'PATCH',
         body: JSON.stringify(project),
       });
-      console.log('API client: Update project response:', result);
+      devLog('API client: Update project response:', result);
       return result;
     } catch (error) {
       console.error('API client: Error updating project:', error);
@@ -364,7 +358,7 @@ export const taskApi = {
       }
     });
 
-    console.log('API getTasks params:', params.toString());
+    devLog('API getTasks params:', params.toString());
     return fetchAPI(`/api/tasks?${params.toString()}`);
   },
 
@@ -375,7 +369,7 @@ export const taskApi = {
       return { task: null };
     }
 
-    console.log('API client: Getting task with ID:', id);
+    devLog('API client: Getting task with ID:', id);
     try {
       const result = await fetchAPI(`/api/tasks/${id}`);
       if (!result || !result.task) {
@@ -383,7 +377,7 @@ export const taskApi = {
         return { task: null };
       }
 
-      console.log('API client: Get task success for ID:', id);
+      devLog('API client: Get task success for ID:', id);
       return result;
     } catch (error) {
       console.error('API client: Error getting task:', error);
@@ -396,7 +390,7 @@ export const taskApi = {
   },
 
   createTask: async (task: any) => {
-    console.log('API client: Creating task, data:', JSON.stringify(task));
+    devLog('API client: Creating task, data:', JSON.stringify(task));
     try {
       // Ensure we have required fields
       if (!task.title) {
@@ -414,7 +408,7 @@ export const taskApi = {
         body: JSON.stringify(taskWithoutStatus),
       });
 
-      console.log('API client: Create task response:', result);
+      devLog('API client: Create task response:', result);
       return result;
     } catch (error) {
       console.error('API client: Error creating task:', error);
@@ -423,7 +417,7 @@ export const taskApi = {
   },
 
   updateTask: async (id: string, task: any) => {
-    console.log('API client: Updating task with ID:', id, 'Data:', task);
+    devLog('API client: Updating task with ID:', id, 'Data:', task);
     try {
       // Remove status if present
       const { status, ...taskWithoutStatus } = task;
@@ -431,7 +425,7 @@ export const taskApi = {
         method: 'PATCH',
         body: JSON.stringify(taskWithoutStatus),
       });
-      console.log('API client: Update task response:', result);
+      devLog('API client: Update task response:', result);
       return result;
     } catch (error) {
       console.error('API client: Error updating task:', error);
@@ -440,12 +434,12 @@ export const taskApi = {
   },
 
   deleteTask: async (id: string) => {
-    console.log('API client: Deleting task with ID:', id);
+    devLog('API client: Deleting task with ID:', id);
     try {
       const result = await fetchAPI(`/api/tasks/${id}`, {
         method: 'DELETE',
       });
-      console.log('API client: Delete task response:', result);
+      devLog('API client: Delete task response:', result);
       return result;
     } catch (error) {
       console.error('API client: Error deleting task:', error);
@@ -512,14 +506,14 @@ export const teamManagementApi = {
 
   getUserTeamMemberships: async (userId: string, page = 1, limit = 10) => {
     try {
-      console.log(`Fetching team memberships for user: ${userId}`);
+      devLog(`Fetching team memberships for user: ${userId}`);
       const params = new URLSearchParams();
       params.append('userId', userId);
       params.append('page', page.toString());
       params.append('limit', limit.toString());
 
       const response = await fetchAPI(`/api/team-management?${params.toString()}`);
-      console.log(`Team memberships response:`, response);
+      devLog(`Team memberships response:`, response);
 
       return response.teamMembers || [];
     } catch (error) {

--- a/lib/ordering/task-ordering.ts
+++ b/lib/ordering/task-ordering.ts
@@ -1,3 +1,4 @@
+import { devLog } from '@/lib/utils/logger';
 import prisma from '@/lib/prisma';
 
 /**
@@ -110,7 +111,7 @@ export async function rebalanceTaskOrders(
     // Execute all updates in a transaction
     await prisma.$transaction(updates);
 
-    console.log(
+    devLog(
       `Rebalanced ${tasks.length} tasks for project ${projectId}, parent ${parentId || 'none'}`
     );
   } catch (error) {

--- a/lib/queries/user-queries.ts
+++ b/lib/queries/user-queries.ts
@@ -1,3 +1,4 @@
+import { devLog } from '@/lib/utils/logger';
 import prisma from '../prisma';
 import { Prisma, User } from '@prisma/client';
 import { hash } from 'bcrypt';
@@ -450,7 +451,7 @@ export async function updateUser(id: string, data: UserUpdateInput) {
     userToUpdate.password = await hash(password, 10);
   }
 
-  console.log('Updating user with data:', userToUpdate);
+  devLog('Updating user with data:', userToUpdate);
 
   const user = await prisma.user.update({
     where: { id },

--- a/lib/service-worker.ts
+++ b/lib/service-worker.ts
@@ -1,3 +1,4 @@
+import { devLog } from '@/lib/utils/logger';
 /**
  * Service Worker Registration Utility
  *
@@ -31,7 +32,7 @@ export const isBackgroundSyncSupported = (): boolean =>
 // Register the service worker with retry mechanism
 export async function registerServiceWorker(maxRetries = 3) {
   if (!isServiceWorkerSupported()) {
-    console.log('Service Workers are not supported in this browser');
+    devLog('Service Workers are not supported in this browser');
     return false;
   }
 
@@ -60,11 +61,11 @@ export async function registerServiceWorker(maxRetries = 3) {
         updateViaCache: 'none', // Always fetch fresh service worker
       });
 
-      console.log('Service Worker registered with scope:', registration.scope);
+      devLog('Service Worker registered with scope:', registration.scope);
 
       // Wait for the service worker to be ready
       await navigator.serviceWorker.ready;
-      console.log('Service Worker is ready');
+      devLog('Service Worker is ready');
 
       return true;
     } catch (error) {
@@ -94,7 +95,7 @@ export async function registerServiceWorker(maxRetries = 3) {
       const jitter = Math.random() * 1000;
       const delay = baseDelay + jitter;
 
-      console.log(`Retrying in ${Math.round(delay)}ms...`);
+      devLog(`Retrying in ${Math.round(delay)}ms...`);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }
@@ -105,7 +106,7 @@ export async function registerServiceWorker(maxRetries = 3) {
 // Request background sync permission
 export async function requestBackgroundSyncPermission() {
   if (!isBackgroundSyncSupported()) {
-    console.log('Background Sync is not supported in this browser');
+    devLog('Background Sync is not supported in this browser');
     return false;
   }
 
@@ -113,7 +114,7 @@ export async function requestBackgroundSyncPermission() {
     // Request notification permission (often needed for background sync)
     const notificationPermission = await Notification.requestPermission();
     if (notificationPermission !== 'granted') {
-      console.log('Notification permission not granted');
+      devLog('Notification permission not granted');
     }
 
     return true;
@@ -126,7 +127,7 @@ export async function requestBackgroundSyncPermission() {
 // Register a background sync
 export async function registerBackgroundSync(): Promise<boolean> {
   if (!isBackgroundSyncSupported()) {
-    console.log('Background Sync is not supported in this browser');
+    devLog('Background Sync is not supported in this browser');
     return false;
   }
 
@@ -136,13 +137,13 @@ export async function registerBackgroundSync(): Promise<boolean> {
     // Register attendance sync
     if ('sync' in registration) {
       await registration.sync.register('attendance-sync');
-      console.log('Attendance background sync registered!');
+      devLog('Attendance background sync registered!');
 
       // Register auto-checkout sync
       await registration.sync.register('auto-checkout-sync');
-      console.log('Auto-checkout background sync registered!');
+      devLog('Auto-checkout background sync registered!');
     } else {
-      console.log('Sync API not available in this browser');
+      devLog('Sync API not available in this browser');
     }
 
     return true;
@@ -155,7 +156,7 @@ export async function registerBackgroundSync(): Promise<boolean> {
 // Register auto-checkout sync specifically
 export async function registerAutoCheckoutSync(): Promise<boolean> {
   if (!isBackgroundSyncSupported()) {
-    console.log('Background Sync is not supported in this browser');
+    devLog('Background Sync is not supported in this browser');
     return false;
   }
 
@@ -163,10 +164,10 @@ export async function registerAutoCheckoutSync(): Promise<boolean> {
     const registration = (await navigator.serviceWorker.ready) as ExtendedServiceWorkerRegistration;
     if ('sync' in registration) {
       await registration.sync.register('auto-checkout-sync');
-      console.log('Auto-checkout sync registered!');
+      devLog('Auto-checkout sync registered!');
       return true;
     } else {
-      console.log('Sync API not available in this browser');
+      devLog('Sync API not available in this browser');
       return false;
     }
   } catch (error) {

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -1,0 +1,5 @@
+export function devLog(...args: unknown[]): void {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(...args);
+  }
+}


### PR DESCRIPTION
## Summary
- wrap debug logs with `devLog()` that skips logging when `NODE_ENV` is `production`
- replace all `console.log` occurrences in `lib/` and `components/`

## Testing
- `npm run lint` *(fails: 7 errors)*
- `npm run type-check`